### PR TITLE
Fix three code bugs

### DIFF
--- a/packages/backend/src/Controllers/Roll/addElectionRollController.ts
+++ b/packages/backend/src/Controllers/Roll/addElectionRollController.ts
@@ -23,11 +23,11 @@ const className = "VoterRolls.Controllers";
 const addElectionRoll = async (req: IElectionRequest & { body: { electionRoll: ElectionRollInput[] } }, res: Response, next: NextFunction) => {
     expectPermission(req.user_auth.roles, permissions.canAddToElectionRoll)
     Logger.info(req, `${className}.addElectionRoll ${req.election.election_id}`);
-    const history = [{
+    const historyEntry = {
         action_type: 'added',
-        actor: req.user.email,
+        actor: req.user?.email,
         timestamp: Date.now(),
-    }]
+    };
     
     // Generate all IDs in parallel first
     const idPromises: Promise<string>[] = req.body.electionRoll.map((rollInput: ElectionRollInput) => 
@@ -47,7 +47,7 @@ const addElectionRoll = async (req: IElectionRequest & { body: { electionRoll: E
         submitted: false,
         precinct: rollInput.precinct,
         state: rollInput.state || ElectionRollState.approved,
-        history: history,
+        history: [{ ...historyEntry }],
         create_date: new Date().toISOString(),
         update_date: Date.now().toString(),
         head: true

--- a/packages/frontend/src/hooks/useFetch.ts
+++ b/packages/frontend/src/hooks/useFetch.ts
@@ -20,14 +20,14 @@ const useFetch = <Message, Response>(url: string, method: 'get' | 'post' | 'put'
     const { setSnack } = useSnackbar()
 
     const makeRequest = async (data?: Message) => {
-        const options = {
-            method: method,
+        const options: RequestInit = {
+            method,
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify(data)
-        }
+            ...(method !== 'get' && data !== undefined ? { body: JSON.stringify(data) } : {})
+        };
         setIsPending(true);
         try {
             const res = await fetch(url, options)

--- a/packages/frontend/src/hooks/useLocalStorage.ts
+++ b/packages/frontend/src/hooks/useLocalStorage.ts
@@ -8,17 +8,16 @@ export const useLocalStorage = <data>(key: string, defaultValue: data|null, upda
     const getStoredValue = (key: string, defaultValue: data|null) => {
         // getting stored value
         const saved = localStorage.getItem(key);
-        let initial: data|null;
-        try {
-            initial = JSON.parse(saved);
-        } catch {
-            initial = null;
-        }
-        if (!initial) {
+        if (saved === null) {
             localStorage.setItem(key, JSON.stringify(defaultValue));
-            return defaultValue
+            return defaultValue;
         }
-        return initial;
+        try {
+            return JSON.parse(saved);
+        } catch {
+            localStorage.setItem(key, JSON.stringify(defaultValue));
+            return defaultValue;
+        }
     }
     const [value, setStoredValue] = useState<data|null>(() => {
         return getStoredValue(key, defaultValue);


### PR DESCRIPTION
## Description

This PR addresses three distinct bugs:

1.  **`useFetch` sends JSON body with GET requests:** Previously, `useFetch` would unconditionally add a JSON body to all requests, including GET requests or when no data was provided. This could lead to server rejections or incorrect caching. The fix ensures a request body is only included for non-GET methods when data is explicitly supplied.
2.  **Election roll history shared across voters:** The `addElectionRoll` function was reusing the same `history` array instance for all new election rolls, causing history mutations for one voter to affect others. The fix now provides each new roll with its own distinct copy of the initial history entry.
3.  **`useLocalStorage` overwrites falsey values:** The `useLocalStorage` hook incorrectly treated legitimate falsey values (e.g., `0`, `false`, `""`) as missing and overwrote them with the default. It also attempted to parse `null`. The updated logic correctly preserves stored falsey values and only applies the default if the key is truly absent or parsing fails.

## Screenshots / Videos (frontend only)

N/A

## Related Issues

---
<a href="https://cursor.com/background-agent?bcId=bc-dfb548e1-7597-4d65-8cae-b1002f1e4262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dfb548e1-7597-4d65-8cae-b1002f1e4262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

